### PR TITLE
Add support for Python 3. Drop support for Python <2.6.

### DIFF
--- a/clearpass/api.py
+++ b/clearpass/api.py
@@ -15,9 +15,14 @@
 # limitations under the License.
 #
 
+from __future__ import print_function
 from requests import Request, Session
 from time import time
-from urlparse import urljoin, urlparse, urlunparse
+# Support both Python 2 and Python 3
+try:
+    from urlparse import urljoin, urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urljoin, urlparse, urlunparse
 
 _session = Session()
 
@@ -94,25 +99,25 @@ class Client:
 		if self.verbose:
 			prep = _session.prepare_request(Request(method=method, url=url, params=query_params,
 				headers=headers, data={}, json=body))
-			print prep.method, prep.path_url
+			print(prep.method, prep.path_url)
 			if prep.headers:
 				for name, value in prep.headers.items():
-					print '%s: %s' % (name, value)
-			print
+					print('%s: %s' % (name, value))
+			print()
 			if prep.body:
-				print prep.body
-			print
+				print(prep.body)
+			print()
 		response = _session.request(method, url, params=query_params,
 			headers=headers, json=body, timeout=self.timeout, verify=not self.insecure)
 		if self.verbose:
-			print 'HTTP/1.1', response.status_code, response.reason
+			print('HTTP/1.1', response.status_code, response.reason)
 			if response.headers:
 				for name, value in response.headers.items():
-					print '%s: %s' % (name, value)
-			print
+					print('%s: %s' % (name, value))
+			print()
 			if response.content:
-				print response.content
-			print
+				print(response.content)
+			print()
 		if response.status_code >= 400:
 			if 'json' in response.headers['Content-Type']:
 				details = response.json()

--- a/cpapi.py
+++ b/cpapi.py
@@ -73,7 +73,7 @@ import re
 import sys
 import warnings
 
-VERSION = 'cpapi.py 1.0'
+VERSION = 'cpapi.py 1.1'
 
 class CommandLineInterface:
 	def main(self):
@@ -96,7 +96,7 @@ class CommandLineInterface:
 				self.args['URL'], query, body, not self.args['--unauthorized'])
 			json.dump(result, sys.stdout, indent=4, sort_keys=True)
 			print("\n")
-		except api.ConfigurationException, e:
+		except api.ConfigurationException as e:
 			sys.stderr.write("ERROR: Configuration error: %s\n" % str(e))
 			exit_status = 3
 		return exit_status


### PR DESCRIPTION
These changes allow this code to be run on Python 3 in addition to Python 2 version 2.6 or later.

By changing the exception syntax to support Python 3, these changes break support for Python < 2.6. It would be possible to [hack in support for Python < 2.6](https://docs.python.org/3.3/howto/pyporting.html) but it is slightly unpleasant and I'd be surprised to learn anyone is using that.

Instructions have not been updated and assume the user is still running Python 2 (which will still work).